### PR TITLE
remove alpha backtracking prediction

### DIFF
--- a/test/nativeexamples.jl
+++ b/test/nativeexamples.jl
@@ -118,7 +118,7 @@ end
 end
 
 @testset "Robinson" begin
-    alf = Alfonso.AlfonsoOpt(verbose=verbflag)
+    alf = Alfonso.AlfonsoOpt(verbose=verbflag, optimtol=1e-5)
     build_namedpoly!(alf, :robinson, 8)
     @time Alfonso.solve!(alf)
     @test Alfonso.get_status(alf) == :Optimal


### PR DESCRIPTION
now, in prediction, we accept alpha if
- just decreased alpha and iterate is the first inside the cone and beta-neighborhood or
- increased alpha and iterate is inside the cone and the first to leave beta-neighborhood

and no longer need to save previous calculated values in cone functions, simplifying the interface to these

reduces iteration count by 30% pretty reliably. may incur additional correction steps, but tests suggest it is overall faster.
