### PR TITLE
add SOC, remove overly aggressive stepping outside beta-neighborhood

### DIFF
--- a/src/nativeinterface.jl
+++ b/src/nativeinterface.jl
@@ -373,14 +373,14 @@ function solve!(alf::AlfonsoOpt)
                     continue
                 end
 
-                # iterate is outside the beta-neighborhood
-                if alphaprevok # TODO technically this should be only if nprediters > 1, but it seems to work
-                    # previous iterate was inside the beta-neighborhood
-                    if alf.predlinesearch
-                        alphapred = alpha*alf.predlsmulti
-                    end
-                    break
-                end
+                # # iterate is outside the beta-neighborhood
+                # if alphaprevok # TODO technically this should be only if nprediters > 1, but it seems to work
+                #     # previous iterate was inside the beta-neighborhood
+                #     if alf.predlinesearch
+                #         alphapred = alpha*alf.predlsmulti
+                #     end
+                #     break
+                # end
             end
 
             # primal iterate is either

--- a/src/primitivecones/secondorder.jl
+++ b/src/primitivecones/secondorder.jl
@@ -1,0 +1,39 @@
+
+# second order cone
+mutable struct SecondOrderCone <: PrimitiveCone
+    dim::Int
+    pnt::AbstractVector{Float64}
+    dist::Float64
+    Hi::Matrix{Float64}
+
+    function SecondOrderCone(dim::Int)
+        prm = new()
+        prm.dim = dim
+        prm.Hi = Matrix{Float64}(undef, dim , dim)
+        return prm
+    end
+end
+
+dimension(prm::SecondOrderCone) = prm.dim
+barrierpar_prm(prm::SecondOrderCone) = 1.0
+getintdir_prm!(arr::AbstractVector{Float64}, prm::SecondOrderCone) = (arr[1] = 1.0; arr[2:end] .= 0.0; arr)
+loadpnt_prm!(prm::SecondOrderCone, pnt::AbstractVector{Float64}) = (prm.pnt = pnt)
+
+function incone_prm(prm::SecondOrderCone)
+    prm.dist = abs2(prm.pnt[1]) - sum(abs2, prm.pnt[j] for j in 2:prm.dim)
+
+    if prm.dist > 0.0
+        mul!(prm.Hi, prm.pnt, prm.pnt')
+        prm.Hi .+= prm.Hi
+        prm.Hi[1,1] -= prm.dist
+        for j in 2:prm.dim
+            prm.Hi[j,j] += prm.dist
+        end
+        return true
+    end
+    return false
+end
+
+calcg_prm!(g::AbstractVector{Float64}, prm::SecondOrderCone) = (g .= inv(prm.dist) .* prm.pnt; g[1] *= -1.0; g)
+# TODO if later use Linv instead of Hinv, see Vandenberghe coneprog.dvi for analytical Linv
+calcHiarr_prm!(prod::AbstractArray{Float64}, arr::AbstractArray{Float64}, prm::SecondOrderCone) = mul!(prod, prm.Hi, arr)

--- a/test/nativeexamples.jl
+++ b/test/nativeexamples.jl
@@ -170,7 +170,7 @@ end
 
 # tolerances not satisfied
 @testset "Rosenbrock" begin
-    alf = Alfonso.AlfonsoOpt(verbose=verbflag, optimtol=1e-4, maxpredsmallsteps=20)
+    alf = Alfonso.AlfonsoOpt(verbose=verbflag, optimtol=1e-5, maxpredsmallsteps=20)
     build_namedpoly!(alf, :rosenbrock, 3)
     @time Alfonso.solve!(alf)
     # @test Alfonso.get_status(alf) == :Optimal
@@ -180,10 +180,25 @@ end
 
 # tolerances not satisfied
 @testset "Schwefel" begin
-    alf = Alfonso.AlfonsoOpt(verbose=verbflag, optimtol=1e-4, maxpredsmallsteps=25)
+    alf = Alfonso.AlfonsoOpt(verbose=verbflag, optimtol=1e-5, maxpredsmallsteps=25)
     build_namedpoly!(alf, :schwefel, 4)
     @time Alfonso.solve!(alf)
     @test Alfonso.get_status(alf) == :Optimal
     @test Alfonso.get_pobj(alf) ≈ 0 atol=1e-3 rtol=1e-3
     @test Alfonso.get_dobj(alf) ≈ 0 atol=1e-3 rtol=1e-3
+end
+
+@testset "small second-order cone problem" begin
+    alf = Alfonso.AlfonsoOpt(verbose=verbflag)
+    c = Float64[0, -1, -1]
+    A = Float64[1 0 0; 0 1 0]
+    b = Float64[1, 1/sqrt(2)]
+    cone = Alfonso.Cone([Alfonso.SecondOrderCone(3)], AbstractUnitRange[1:3])
+    Alfonso.load_data!(alf, A, b, c, cone)
+    @time Alfonso.solve!(alf)
+    @test Alfonso.get_status(alf) == :Optimal
+    @test Alfonso.get_pobj(alf) ≈ -sqrt(2) atol=1e-4 rtol=1e-4
+    @test Alfonso.get_dobj(alf) ≈ Alfonso.get_pobj(alf) atol=1e-4 rtol=1e-4
+    @test Alfonso.get_y(alf) ≈ [-sqrt(2), 0.0] atol=1e-4 rtol=1e-4
+    @test Alfonso.get_x(alf) ≈ [1.0, 1/sqrt(2), 1/sqrt(2)] atol=1e-4 rtol=1e-4
 end


### PR DESCRIPTION
the aggressive stepping improved iteration counts and some overall times on old tests, but it was not guaranteed to converge and made some tests more fragile. since it made the little SOC test fragile, I have disabled it. it could be an option. but I am working on a smarter way to step anyway.