### PR TITLE
clean up examples; add poly envelope example in JuMP

### DIFF
--- a/examples/envelope/jump.jl
+++ b/examples/envelope/jump.jl
@@ -1,0 +1,70 @@
+#=
+Copyright 2018, Chris Coey and contributors
+
+see description in examples/envelope/native.jl, which formulates the dual envelope problem in the native interface; here we formulate the corresponding primal problem
+=#
+
+using Hypatia
+import MathOptInterface
+MOI = MathOptInterface
+using JuMP
+# using MultivariatePolynomials
+# using DynamicPolynomials
+# using SemialgebraicSets
+# using PolyJuMP
+# using SumOfSquares
+using LinearAlgebra
+using Random
+using Test
+
+function build_JuMP_envelope(
+    npoly::Int,
+    deg::Int,
+    n::Int,
+    d::Int;
+    rseed::Int = 1,
+    )
+    # generate interpolation
+    # TODO this should be built into the modeling layer
+    @assert deg <= d
+    (L, U, pts, P0, P, w) = Hypatia.interpolate(n, d, calc_w=true)
+    LWts = fill(binomial(n+d-1, n), n)
+    wtVals = 1.0 .- pts.^2
+    PWts = [Array((qr(Diagonal(sqrt.(wtVals[:, j])) * P[:, 1:LWts[j]])).Q) for j in 1:n]
+
+    # generate random polynomials
+    Random.seed!(rseed)
+    LDegs = binomial(n+deg, n)
+    polys = P0[:, 1:LDegs]*rand(-9:9, LDegs, npoly)
+
+    # build JuMP model
+    model = Model(with_optimizer(Hypatia.Optimizer, verbose=true))
+    @variable(model, fpv[j in 1:U]) # values at Fekete points
+    @objective(model, Max, dot(fpv, w)) # integral over domain (via quadrature)
+    @constraint(model, [i in 1:npoly], polys[:,i] .- fpv in WSOSPolyInterpCone(U, [P, PWts...]))
+
+    return (model, fpv)
+end
+
+function run_JuMP_envelope()
+    (npoly, deg, n, d) =
+        2, 3, 1, 4
+        # 2, 3, 2, 4
+        # 2, 3, 3, 4
+
+    (model, fpv) = build_JuMP_envelope(npoly, deg, n, d)
+    JuMP.optimize!(model)
+
+    term_status = JuMP.termination_status(model)
+    pobj = JuMP.objective_value(model)
+    dobj = JuMP.objective_bound(model)
+    pr_status = JuMP.primal_status(model)
+    du_status = JuMP.dual_status(model)
+
+    @test term_status == MOI.Success
+    @test pr_status == MOI.FeasiblePoint
+    @test du_status == MOI.FeasiblePoint
+    @test pobj ≈ dobj atol=1e-4 rtol=1e-4
+
+    return nothing
+end

--- a/examples/linearopt/native.jl
+++ b/examples/linearopt/native.jl
@@ -12,7 +12,7 @@ using DelimitedFiles
 using Random
 using Test
 
-function build_linearopt!(
+function build_linearopt(
     m::Int,
     n::Int;
     use_data::Bool = false,
@@ -21,7 +21,6 @@ function build_linearopt!(
     tosparse::Bool = false,
     rseed::Int = 1,
     )
-
     # set up problem data
     if use_data
         # use provided data in data folder
@@ -55,15 +54,15 @@ function run_linearopt()
     # optionally use fixed data in folder
     # select the random matrix size, dense/sparse, sparsity fraction
     (c, A, b, G, h, cone) =
-        # build_linearopt!(500, 1000, use_data=true)
-        # build_linearopt!(500, 1000)
-        build_linearopt!(15, 20)
+        # build_linearopt(500, 1000, use_data=true)
+        # build_linearopt(500, 1000)
+        build_linearopt(15, 20)
 
     Hypatia.check_data(c, A, b, G, h, cone)
     (c1, A1, b1, G1, prkeep, dukeep, Q2, RiQ1) = Hypatia.preprocess_data(c, A, b, G, useQR=true)
     L = Hypatia.QRSymmCache(c1, A1, b1, G1, h, cone, Q2, RiQ1)
 
-    mdl = Hypatia.Model(maxiter=100, verbose=false)
+    mdl = Hypatia.Model(maxiter=100, verbose=true)
     Hypatia.load_data!(mdl, c1, A1, b1, G1, h, cone, L)
     Hypatia.solve!(mdl)
 

--- a/examples/namedpoly/native.jl
+++ b/examples/namedpoly/native.jl
@@ -12,11 +12,10 @@ using Hypatia
 using LinearAlgebra
 using Test
 
-function build_namedpoly!(
+function build_namedpoly(
     polyname::Symbol,
     d::Int,
     )
-
     # get data for named polynomial
     (n, lbs, ubs, deg, fn) = polys[polyname]
     if d < ceil(Int, deg/2)
@@ -48,23 +47,23 @@ end
 function run_namedpoly()
     # select the named polynomial to minimize and the SOS degree (to be squared)
     (c, A, b, G, h, cone) =
-        # build_namedpoly!(:butcher, 2)
-        # build_namedpoly!(:caprasse, 4)
-        # build_namedpoly!(:goldsteinprice, 7)
-        # build_namedpoly!(:heart, 2)
-        # build_namedpoly!(:lotkavolterra, 3)
-        # build_namedpoly!(:magnetism7, 2)
-        # build_namedpoly!(:motzkin, 7)
-        build_namedpoly!(:reactiondiffusion, 3)
-        # build_namedpoly!(:robinson, 8)
-        # build_namedpoly!(:rosenbrock, 4)
-        # build_namedpoly!(:schwefel, 3)
+        # build_namedpoly(:butcher, 2)
+        # build_namedpoly(:caprasse, 4)
+        # build_namedpoly(:goldsteinprice, 7)
+        # build_namedpoly(:heart, 2)
+        # build_namedpoly(:lotkavolterra, 3)
+        # build_namedpoly(:magnetism7, 2)
+        # build_namedpoly(:motzkin, 7)
+        build_namedpoly(:reactiondiffusion, 3)
+        # build_namedpoly(:robinson, 8)
+        # build_namedpoly(:rosenbrock, 4)
+        # build_namedpoly(:schwefel, 3)
 
     Hypatia.check_data(c, A, b, G, h, cone)
     (c1, A1, b1, G1, prkeep, dukeep, Q2, RiQ1) = Hypatia.preprocess_data(c, A, b, G, useQR=true)
     L = Hypatia.QRSymmCache(c1, A1, b1, G1, h, cone, Q2, RiQ1)
 
-    mdl = Hypatia.Model(maxiter=100, verbose=false)
+    mdl = Hypatia.Model(maxiter=100, verbose=true)
     Hypatia.load_data!(mdl, c1, A1, b1, G1, h, cone, L)
     Hypatia.solve!(mdl)
 

--- a/test/examples.jl
+++ b/test/examples.jl
@@ -5,32 +5,32 @@ Copyright 2018, Chris Coey and contributors
 function _envelope1(; verbose, lscachetype)
     # dense methods
     mdl = Hypatia.Model(verbose=verbose)
-    (c, A, b, G, h, cone) = build_envelope!(2, 5, 1, 5, use_data=true, dense=true)
+    (c, A, b, G, h, cone) = build_envelope(2, 5, 1, 5, use_data=true, dense=true)
     r = solveandcheck(mdl, c, A, b, G, h, cone, lscachetype)
     @test r.status == :Optimal
-    @test r.pobj ≈ -25.502777 atol=1e-4 rtol=1e-4
+    @test r.pobj ≈ 25.502777 atol=1e-4 rtol=1e-4
     @test r.niters <= 35
 
     # sparse methods
     mdl = Hypatia.Model(verbose=verbose)
-    (c, A, b, G, h, cone) = build_envelope!(2, 5, 1, 5, use_data=true, dense=false)
+    (c, A, b, G, h, cone) = build_envelope(2, 5, 1, 5, use_data=true, dense=false)
     r = solveandcheck(mdl, c, A, b, G, h, cone, lscachetype)
     @test r.status == :Optimal
-    @test r.pobj ≈ -25.502777 atol=1e-4 rtol=1e-4
+    @test r.pobj ≈ 25.502777 atol=1e-4 rtol=1e-4
     @test r.niters <= 35
 end
 
 function _envelope2(; verbose, lscachetype)
     # dense methods
     mdl = Hypatia.Model(verbose=verbose)
-    (c, A, b, G, h, cone) = build_envelope!(2, 4, 2, 7, dense=true)
+    (c, A, b, G, h, cone) = build_envelope(2, 4, 2, 7, dense=true)
     rd = solveandcheck(mdl, c, A, b, G, h, cone, lscachetype)
     @test rd.status == :Optimal
     @test rd.niters <= 60
 
     # sparse methods
     mdl = Hypatia.Model(verbose=verbose)
-    (c, A, b, G, h, cone) = build_envelope!(2, 4, 2, 7, dense=false)
+    (c, A, b, G, h, cone) = build_envelope(2, 4, 2, 7, dense=false)
     rs = solveandcheck(mdl, c, A, b, G, h, cone, lscachetype)
     @test rs.status == :Optimal
     @test rs.niters <= 60
@@ -40,7 +40,7 @@ end
 
 function _envelope3(; verbose, lscachetype)
     mdl = Hypatia.Model(verbose=verbose)
-    (c, A, b, G, h, cone) = build_envelope!(2, 3, 3, 5, dense=false)
+    (c, A, b, G, h, cone) = build_envelope(2, 3, 3, 5, dense=false)
     r = solveandcheck(mdl, c, A, b, G, h, cone, lscachetype)
     @test r.status == :Optimal
     @test r.niters <= 60
@@ -48,23 +48,23 @@ end
 
 function _envelope4(; verbose, lscachetype)
     mdl = Hypatia.Model(verbose=verbose) # tolrelopt=1e-5, tolabsopt=1e-6, tolfeas=1e-6
-    (c, A, b, G, h, cone) = build_envelope!(2, 2, 4, 3, dense=false)
+    (c, A, b, G, h, cone) = build_envelope(2, 2, 4, 3, dense=false)
     r = solveandcheck(mdl, c, A, b, G, h, cone, lscachetype)
     @test r.status == :Optimal
-    @test r.niters <= 65
+    @test r.niters <= 55
 end
 
 function _linearopt1(; verbose, lscachetype)
     # dense methods
     mdl = Hypatia.Model(verbose=verbose)
-    (c, A, b, G, h, cone) = build_linearopt!(25, 50, dense=true, tosparse=false)
+    (c, A, b, G, h, cone) = build_linearopt(25, 50, dense=true, tosparse=false)
     rd = solveandcheck(mdl, c, A, b, G, h, cone, lscachetype)
     @test rd.status == :Optimal
     @test rd.niters <= 45
 
     # sparse methods
     mdl = Hypatia.Model(verbose=verbose)
-    (c, A, b, G, h, cone) = build_linearopt!(25, 50, dense=true, tosparse=true)
+    (c, A, b, G, h, cone) = build_linearopt(25, 50, dense=true, tosparse=true)
     rs = solveandcheck(mdl, c, A, b, G, h, cone, lscachetype)
     @test rs.status == :Optimal
     @test rs.niters <= 45
@@ -74,7 +74,7 @@ end
 
 function _linearopt2(; verbose, lscachetype)
     mdl = Hypatia.Model(verbose=verbose, tolfeas=1e-9)
-    (c, A, b, G, h, cone) = build_linearopt!(500, 1000, use_data=true, dense=true)
+    (c, A, b, G, h, cone) = build_linearopt(500, 1000, use_data=true, dense=true)
     r = solveandcheck(mdl, c, A, b, G, h, cone, lscachetype)
     @test r.status == :Optimal
     @test r.niters <= 75
@@ -85,7 +85,7 @@ end
 
 function _namedpoly1(; verbose, lscachetype)
     mdl = Hypatia.Model(verbose=verbose)
-    (c, A, b, G, h, cone) = build_namedpoly!(:butcher, 2)
+    (c, A, b, G, h, cone) = build_namedpoly(:butcher, 2)
     r = solveandcheck(mdl, c, A, b, G, h, cone, lscachetype)
     @test r.status == :Optimal
     @test r.niters <= 45
@@ -94,7 +94,7 @@ end
 
 function _namedpoly2(; verbose, lscachetype)
     mdl = Hypatia.Model(verbose=verbose)
-    (c, A, b, G, h, cone) = build_namedpoly!(:caprasse, 4)
+    (c, A, b, G, h, cone) = build_namedpoly(:caprasse, 4)
     r = solveandcheck(mdl, c, A, b, G, h, cone, lscachetype)
     @test r.status == :Optimal
     @test r.niters <= 45
@@ -103,7 +103,7 @@ end
 
 function _namedpoly3(; verbose, lscachetype)
     mdl = Hypatia.Model(verbose=verbose, tolfeas=1e-10)
-    (c, A, b, G, h, cone) = build_namedpoly!(:goldsteinprice, 6)
+    (c, A, b, G, h, cone) = build_namedpoly(:goldsteinprice, 6)
     r = solveandcheck(mdl, c, A, b, G, h, cone, lscachetype)
     @test r.status == :Optimal
     @test r.niters <= 60
@@ -112,7 +112,7 @@ end
 
 function _namedpoly4(; verbose, lscachetype)
     mdl = Hypatia.Model(verbose=verbose)
-    (c, A, b, G, h, cone) = build_namedpoly!(:heart, 2)
+    (c, A, b, G, h, cone) = build_namedpoly(:heart, 2)
     r = solveandcheck(mdl, c, A, b, G, h, cone, lscachetype)
     @test r.status == :Optimal
     # @test r.niters <= 40
@@ -121,7 +121,7 @@ end
 
 function _namedpoly5(; verbose, lscachetype)
     mdl = Hypatia.Model(verbose=verbose)
-    (c, A, b, G, h, cone) = build_namedpoly!(:lotkavolterra, 3)
+    (c, A, b, G, h, cone) = build_namedpoly(:lotkavolterra, 3)
     r = solveandcheck(mdl, c, A, b, G, h, cone, lscachetype)
     @test r.status == :Optimal
     @test r.niters <= 45
@@ -130,7 +130,7 @@ end
 
 function _namedpoly6(; verbose, lscachetype)
     mdl = Hypatia.Model(verbose=verbose)
-    (c, A, b, G, h, cone) = build_namedpoly!(:magnetism7, 2)
+    (c, A, b, G, h, cone) = build_namedpoly(:magnetism7, 2)
     r = solveandcheck(mdl, c, A, b, G, h, cone, lscachetype)
     @test r.status == :Optimal
     @test r.niters <= 35
@@ -139,7 +139,7 @@ end
 
 function _namedpoly7(; verbose, lscachetype)
     mdl = Hypatia.Model(verbose=verbose)
-    (c, A, b, G, h, cone) = build_namedpoly!(:motzkin, 7)
+    (c, A, b, G, h, cone) = build_namedpoly(:motzkin, 7)
     r = solveandcheck(mdl, c, A, b, G, h, cone, lscachetype)
     @test r.status == :Optimal
     @test r.niters <= 45
@@ -148,7 +148,7 @@ end
 
 function _namedpoly8(; verbose, lscachetype)
     mdl = Hypatia.Model(verbose=verbose)
-    (c, A, b, G, h, cone) = build_namedpoly!(:reactiondiffusion, 4)
+    (c, A, b, G, h, cone) = build_namedpoly(:reactiondiffusion, 4)
     r = solveandcheck(mdl, c, A, b, G, h, cone, lscachetype)
     @test r.status == :Optimal
     @test r.niters <= 40
@@ -157,7 +157,7 @@ end
 
 function _namedpoly9(; verbose, lscachetype)
     mdl = Hypatia.Model(verbose=verbose)
-    (c, A, b, G, h, cone) = build_namedpoly!(:robinson, 8)
+    (c, A, b, G, h, cone) = build_namedpoly(:robinson, 8)
     r = solveandcheck(mdl, c, A, b, G, h, cone, lscachetype)
     @test r.status == :Optimal
     @test r.niters <= 40
@@ -166,7 +166,7 @@ end
 
 function _namedpoly10(; verbose, lscachetype)
     mdl = Hypatia.Model(verbose=verbose, tolfeas=1e-10)
-    (c, A, b, G, h, cone) = build_namedpoly!(:rosenbrock, 5)
+    (c, A, b, G, h, cone) = build_namedpoly(:rosenbrock, 5)
     r = solveandcheck(mdl, c, A, b, G, h, cone, lscachetype)
     @test r.status == :Optimal
     @test r.niters <= 70
@@ -175,7 +175,7 @@ end
 
 function _namedpoly11(; verbose, lscachetype)
     mdl = Hypatia.Model(verbose=verbose, tolfeas=1e-9)
-    (c, A, b, G, h, cone) = build_namedpoly!(:schwefel, 4)
+    (c, A, b, G, h, cone) = build_namedpoly(:schwefel, 4)
     r = solveandcheck(mdl, c, A, b, G, h, cone, lscachetype)
     @test r.status == :Optimal
     @test r.niters <= 60

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -138,10 +138,11 @@ end
 # examples in src/examples/ folder
 egs_dir = joinpath(@__DIR__, "../examples")
 include(joinpath(egs_dir, "envelope/native.jl"))
+include(joinpath(egs_dir, "envelope/jump.jl"))
+include(joinpath(egs_dir, "expdesign/jump.jl"))
 include(joinpath(egs_dir, "linearopt/native.jl"))
 include(joinpath(egs_dir, "namedpoly/native.jl"))
 include(joinpath(egs_dir, "namedpoly/jump.jl"))
-include(joinpath(egs_dir, "expdesign/jump.jl"))
 
 include(joinpath(@__DIR__, "examples.jl"))
 @info("starting varied examples tests")
@@ -174,13 +175,14 @@ testfuns = [
 end
 
 
-@info("starting default examples tests")
+@info("starting verbose default examples tests")
 testfuns = [
     run_envelope,
+    run_JuMP_envelope,
+    run_JuMP_expdesign,
     run_linearopt,
     run_namedpoly,
-    run_JuMP_expdesign, # verbose
-    run_JuMP_namedpoly, # verbose
+    run_JuMP_namedpoly,
     ]
 @testset "default examples: $testfun" for testfun in testfuns
     testfun()


### PR DESCRIPTION
and make WSOS interpolation cone an exported MOI vector set

I changed the native envelope example to use the primal formulation (which needs no equality constraints)

for the new JuMP envelope example, I am not currently using PolyJuMP/SumOfSquares. rather I do the interpolation and implicit integration in the objective manually. later I would like this to be handled by future features in PolyJuMP (etc).

I'll merge this now and note that examples/envelope/jump.jl is working but WIP for the reason above.