### PR TITLE
use bunchkaufman without svx; use lu instead of qr in naive linear system method; reenable some tests

### DIFF
--- a/examples/shapeconregr/jump.jl
+++ b/examples/shapeconregr/jump.jl
@@ -79,7 +79,7 @@ function build_shapeconregr_PSD(
     mono_bss = get_domain_inequalities(sd.mono_dom, x)
     conv_bss = get_domain_inequalities(sd.conv_dom, x)
 
-    model = SOSModel(with_optimizer(Hypatia.Optimizer, verbose=true, usedense=usedense))
+    model = SOSModel(with_optimizer(Hypatia.Optimizer, verbose=true, usedense=usedense, lscachetype=Hypatia.QRSymmCache))
     @variable(model, p, PolyJuMP.Poly(monomials(x, 0:r)))
 
     if use_leastsqobj
@@ -132,7 +132,7 @@ function build_shapeconregr_WSOS(
     @polyvar x[1:n]
     @polyvar w[1:n]
 
-    model = SOSModel(with_optimizer(Hypatia.Optimizer, verbose=true, usedense=usedense))
+    model = SOSModel(with_optimizer(Hypatia.Optimizer, verbose=true, usedense=usedense, lscachetype=Hypatia.QRSymmCache))
     @variable(model, p, PolyJuMP.Poly(monomials(x, 0:r)))
 
     if use_leastsqobj

--- a/src/Hypatia.jl
+++ b/src/Hypatia.jl
@@ -7,8 +7,8 @@ module Hypatia
     using LinearAlgebra
     using SparseArrays
 
-    using LinearAlgebra: BlasInt
-    include("lapack.jl")
+    # using LinearAlgebra: BlasInt
+    # include("lapack.jl")
 
     import FFTW
     import Combinatorics

--- a/src/linsyssolvers/naive.jl
+++ b/src/linsyssolvers/naive.jl
@@ -1,4 +1,6 @@
 #=
+Copyright 2018, Chris Coey and contributors
+
 naive method that simply performs one high-dimensional linear system solve
 TODO should allow LHS6 to be sparse
 =#
@@ -135,7 +137,7 @@ function solvelinsys6!(
         calcHarr_prmtv!(view(L.LHS6copy, L.tzk - 1 .+ L.cone.idxs[k], coloffset - 1 .+ L.cone.idxs[k]), Matrix(mu*I, dim, dim), L.cone.prmtvs[k])
     end
 
-    F = qr!(L.LHS6copy)
+    F = lu!(L.LHS6copy)
     ldiv!(F, rhs)
 
     @. @views begin

--- a/test/examples.jl
+++ b/test/examples.jl
@@ -1,5 +1,5 @@
 #=
-Copyright 2018, Chris Coey and contributors
+Copyright 2018, Chris Coey, Lea Kapelevich and contributors
 =#
 
 function _envelope1(; verbose, lscachetype)
@@ -165,16 +165,16 @@ function _namedpoly9(; verbose, lscachetype)
 end
 
 function _namedpoly10(; verbose, lscachetype)
-    mdl = Hypatia.Model(verbose=verbose, tolfeas=5e-10)
+    mdl = Hypatia.Model(verbose=verbose, tolfeas=2e-10)
     (c, A, b, G, h, cone) = build_namedpoly(:rosenbrock, 5)
     r = solveandcheck(mdl, c, A, b, G, h, cone, lscachetype, atol=1e-3)
     @test r.status == :Optimal
-    @test r.niters <= 65
+    @test r.niters <= 70
     @test r.pobj ≈ 0 atol=1e-3 rtol=1e-3
 end
 
 function _namedpoly11(; verbose, lscachetype)
-    mdl = Hypatia.Model(verbose=verbose, tolfeas=1e-9)
+    mdl = Hypatia.Model(verbose=verbose, tolfeas=1e-10)
     (c, A, b, G, h, cone) = build_namedpoly(:schwefel, 4)
     r = solveandcheck(mdl, c, A, b, G, h, cone, lscachetype, atol=1e-3)
     @test r.status == :Optimal

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,8 +1,5 @@
 #=
-Copyright 2018, Chris Coey and contributors
-
-# TODO add a progress meter to silent tests?
-# TODO don't print "Hypatia." before linsyscache types in testset printing
+Copyright 2018, Chris Coey, Lea Kapelevich and contributors
 =#
 
 using Hypatia
@@ -102,14 +99,13 @@ function solveandcheck(
     return (x=x, y=y, s=s, z=z, pobj=pobj, dobj=dobj, status=status, stime=stime, niters=niters)
 end
 
-
 # native interface tests
 include(joinpath(@__DIR__, "native.jl"))
 @info("starting native interface tests")
 verbose = false
 lscachetypes = [
     Hypatia.QRSymmCache,
-    # Hypatia.NaiveCache,
+    Hypatia.NaiveCache,
     ]
 testfuns = [
     _dimension1,
@@ -158,7 +154,7 @@ end
 
 
 @info("starting native examples tests")
-verbose = true
+verbose = false
 lscachetypes = [
     Hypatia.QRSymmCache,
     # Hypatia.NaiveCache, # slow
@@ -179,13 +175,12 @@ testfuns = [
     _namedpoly7,
     _namedpoly8,
     _namedpoly9,
-    # _namedpoly10, # numerically unstable
+    _namedpoly10, # numerically unstable
     _namedpoly11,
     ]
 @testset "native examples: $testfun, $lscachetype" for testfun in testfuns, lscachetype in lscachetypes
     testfun(verbose=verbose, lscachetype=lscachetype)
 end
-
 
 @info("starting JuMP examples tests")
 testfuns = [
@@ -204,7 +199,7 @@ testfuns = [
     _shapeconregr3_JuMP,
     _shapeconregr4_JuMP,
     _shapeconregr5_JuMP,
-    # _shapeconregr6_JuMP, # numerically unstable
+    _shapeconregr6_JuMP, # numerically unstable
     _shapeconregr7_JuMP,
     _shapeconregr8_JuMP,
     # _shapeconregr9_JuMP, # numerically unstable
@@ -218,6 +213,7 @@ testfuns = [
 @testset "JuMP examples: $testfun" for testfun in testfuns
     testfun()
 end
+
 
 @info("starting verbose default examples tests")
 testfuns = [


### PR DESCRIPTION
it seems that the LAPACK *svx functions don't really help so I have commented them and gone back to bunchkaufman.

changing from qr to lu in naive linear system method improves reliability. surprisingly though, qrsymm method seems to do better, at least on our tests.