### PR TITLE
Update truemin values based on solves that have made more progress

### DIFF
--- a/test/examples.jl
+++ b/test/examples.jl
@@ -378,7 +378,7 @@ function _shapeconregr10_JuMP()
     (n, deg, npoints, signal_ratio, f) = (2, 4, 100, 0.0, x -> exp(norm(x)))
     (X, y) = generateregrdata(f, -1.0, 1.0, n, npoints, signal_ratio=signal_ratio)
     (mdl, p) = build_shapeconregr_WSOS(X, y, deg, ShapeData(n), use_leastsqobj=true)
-    truemin = 4.7430e-2 # <---- not verified with SDP like others
+    truemin = 5.0209e-02 # <---- not verified with SDP like others
     solveandcheck_JuMP(mdl, truemin)
 end
 
@@ -386,8 +386,8 @@ function _shapeconregr11_JuMP()
     (n, deg, npoints, signal_ratio, f) = (2, 5, 100, 10.0, x -> exp(norm(x)))
     (X, y) = generateregrdata(f, 0.5, 2.0, n, npoints, signal_ratio=signal_ratio)
     shapedata = ShapeData(Hypatia.Box(0.5*ones(n), 2*ones(n)), Hypatia.Box(0.5*ones(n), 2*ones(n)), ones(n), 1)
-    (mdl, p) = build_shapeconregr_PSD(X, y, deg, shapedata, use_leastsqobj=true)
-    truemin = 2.2219e-1 # <---- may be inaccurate
+    (mdl, p) = build_shapeconregr_WSOS(X, y, deg, shapedata, use_leastsqobj=true)
+    truemin = 0.2283 # <---- not verified with SDP like others
     solveandcheck_JuMP(mdl, truemin)
 end
 
@@ -396,7 +396,7 @@ function _shapeconregr12_JuMP()
     (X, y) = generateregrdata(f, 0.5, 2.0, n, npoints, signal_ratio=signal_ratio)
     shapedata = ShapeData(Hypatia.Box(0.5*ones(n), 2*ones(n)), Hypatia.Box(0.5*ones(n), 2*ones(n)), ones(n), 1)
     (mdl, p) = build_shapeconregr_PSD(X, y, deg, shapedata, use_leastsqobj=true)
-    truemin = 2.2219e-1 # <---- may be inaccurate
+    truemin = 0.2283 # <---- not verified with SDP
     solveandcheck_JuMP(mdl, truemin)
 end
 


### PR DESCRIPTION
`_shapeconregr11_JuMP` should have been a WSOS test not an SDP test. 

In example 10 the new value of truemin is based on what I'm getting with both the SOS matrix cone and the current SOS cone.

In example 11 the new value of truemin is based on what I'm getting with the SOS matrix cone which gets to an optimal solution while the current formulations fail.