### PR TITLE
prevent rescaling of empty matrices/vectors, check dimension of entropy cone

### DIFF
--- a/src/Cones/episumperentropy.jl
+++ b/src/Cones/episumperentropy.jl
@@ -59,6 +59,7 @@ mutable struct EpiSumPerEntropy{T <: Real} <: Cone{T}
         max_neighborhood::Real = default_max_neighborhood(),
         ) where {T <: Real}
         @assert dim >= 3
+        @assert isodd(dim)
         cone = new{T}()
         cone.use_dual_barrier = use_dual
         cone.use_heuristic_neighborhood = use_heuristic_neighborhood

--- a/src/Solvers/initialize.jl
+++ b/src/Solvers/initialize.jl
@@ -54,14 +54,20 @@ function rescale_data(solver::Solver{T}) where {T <: Real}
         end
     end
 
-    cdiag = Diagonal(c_scale)
-    model.c = cdiag \ model.c
-    model.A = model.A / cdiag
-    model.A ./= b_scale
-    model.G = model.G / cdiag
-    model.G ./= h_scale
-    model.b = Diagonal(b_scale) \ model.b
-    model.h = Diagonal(h_scale) \ model.h
+    if !isempty(model.c)
+        cdiag = Diagonal(c_scale)
+        model.c = cdiag \ model.c
+        model.A = model.A / cdiag
+        model.G = model.G / cdiag
+    end
+    if !isempty(model.b)
+        model.b = Diagonal(b_scale) \ model.b
+        model.A ./= b_scale
+    end
+    if !isempty(model.h)
+        model.h = Diagonal(h_scale) \ model.h
+        model.G ./= h_scale
+    end
 
     return solver.model
 end

--- a/test/moicones.jl
+++ b/test/moicones.jl
@@ -184,10 +184,10 @@ function test_moi_cones(T::Type{<:Real})
     end
 
     @testset "EpiSumPerEntropy" begin
-        moi_cone = HYP.EpiSumPerEntropyCone{T}(4)
+        moi_cone = HYP.EpiSumPerEntropyCone{T}(5)
         hyp_cone = HYP.cone_from_moi(T, moi_cone)
         @test hyp_cone isa CO.EpiSumPerEntropy{T}
-        @test MOI.dimension(moi_cone) == CO.dimension(hyp_cone) == 4
+        @test MOI.dimension(moi_cone) == CO.dimension(hyp_cone) == 5
     end
 
     @testset "HypoGeoMean" begin


### PR DESCRIPTION
without the isempty checks, some MOI tests were failing because we were error-ing on dividing things with zero rows