### PR TITLE
loosen tols if possible for instances where no stepper converges and updates to analysis

### DIFF
--- a/examples/centralpolymat/JuMP_test.jl
+++ b/examples/centralpolymat/JuMP_test.jl
@@ -1,4 +1,5 @@
 
+relaxed_tols = (default_tol_relax = 100,)
 insts = OrderedDict()
 insts["minimal"] = [
     # rootdet
@@ -44,7 +45,7 @@ insts["fast"] = [
 insts["various"] = [
     ((2, 5, MatInvEigOrd()),),
     ((2, 5, MatNegLogEigOrd()),),
-    ((2, 4, MatPower12EigOrd(1.5)),),
+    ((2, 4, MatPower12EigOrd(1.5)), nothing, relaxed_tols),
     ((2, 4, MatNegEntropyEigOrd()),),
     ((2, 10, MatNegGeomEFExp()),),
     ((2, 8, MatNegGeomEFPow()),),
@@ -60,7 +61,7 @@ insts["various"] = [
     ((3, 5, MatPower12(1.5)),),
     ((3, 5, MatNegExp1()),),
     ((3, 4, MatPower12Conj(1.5)),),
-    ((5, 2, MatNegExp1EigOrd()),),
+    ((5, 2, MatNegExp1EigOrd()), nothing, relaxed_tols),
     ((5, 2, MatPower12ConjEigOrd(1.5)),),
     ((5, 3, MatInvDirect()),),
     ((5, 3, MatNegLogDirect()),),

--- a/examples/densityest/JuMP_test.jl
+++ b/examples/densityest/JuMP_test.jl
@@ -1,5 +1,4 @@
 
-relaxed_tols = (default_tol_relax = 1000,)
 insts = OrderedDict()
 insts["minimal"] = [
     ((5, 2, 2, true, true, true),),
@@ -44,8 +43,6 @@ insts["various"] = [
     ((50, 32, 2, true, false, false),),
     ((50, 32, 2, true, false, false), :ExpPSD),
     ((50, 32, 2, true, false, false), :SOCExpPSD),
-    ((50, 32, 2, false, false, false), nothing, relaxed_tols),
-    ((50, 32, 2, false, false, true), nothing, relaxed_tols),
     ((:iris, 6, true, true, true),),
     ((:cancer, 4, true, true, true),),
     ]

--- a/examples/lyapunovstability/JuMP_test.jl
+++ b/examples/lyapunovstability/JuMP_test.jl
@@ -25,11 +25,9 @@ insts["various"] = [
     ((6, 6, false, true),),
     ((6, 6, false, false),),
     ((12, 12, true, true), nothing, relaxed_tols),
-    ((12, 12, true, false), nothing, relaxed_tols),
     ((12, 12, false, true),),
     ((12, 12, false, false),),
     ((24, 24, true, true), nothing, relaxed_tols),
-    ((24, 24, true, false), nothing, relaxed_tols),
     ((24, 24, false, true), nothing, relaxed_tols),
     ((24, 24, false, false), nothing, relaxed_tols),
     ]

--- a/examples/maxvolume/JuMP_test.jl
+++ b/examples/maxvolume/JuMP_test.jl
@@ -23,7 +23,7 @@ insts["various"] = [
     ((1000, true, false),),
     ((1000, false, true),),
     ((1000, true, false), :SOCExpPSD),
-    ((1000, false, true), :SOCExpPSD),
+    ((1000, false, true), :SOCExpPSD, relaxed_tols),
     ((2000, true, false),),
     ((2000, false, true),),
     ((2000, true, false), :SOCExpPSD),

--- a/examples/maxvolume/native_test.jl
+++ b/examples/maxvolume/native_test.jl
@@ -16,10 +16,10 @@ insts["fast"] = [
     ]
 insts["various"] = [
     ((750, true, false, false),),
-    ((750, false, true, false), (default_tol_relax = 100,)),
+    ((750, false, true, false), (default_tol_relax = 1000,)),
     ((750, false, false, true),),
     ((1500, true, false, false),),
-    ((1500, false, true, false), (default_tol_relax = 100,)),
+    ((1500, false, true, false), (default_tol_relax = 1000,)),
     ((1500, false, false, true),),
     ]
 return (MaxVolumeNative, insts)

--- a/examples/maxvolume/native_test.jl
+++ b/examples/maxvolume/native_test.jl
@@ -16,10 +16,8 @@ insts["fast"] = [
     ]
 insts["various"] = [
     ((750, true, false, false),),
-    ((750, false, true, false), (default_tol_relax = 1000,)),
     ((750, false, false, true),),
     ((1500, true, false, false),),
-    ((1500, false, true, false), (default_tol_relax = 1000,)),
     ((1500, false, false, true),),
     ]
 return (MaxVolumeNative, insts)

--- a/examples/normconepoly/JuMP_test.jl
+++ b/examples/normconepoly/JuMP_test.jl
@@ -22,5 +22,16 @@ insts["fast"] = [
     ((:polys8, 2, false, false),),
     ((:polys9, 2, false, false),),
     ]
-insts["various"] = insts["fast"]
+insts["various"] = [
+    ((:polys2, 2, true, true),),
+    ((:polys3, 2, true, true),),
+    ((:polys4, 4, true, true),),
+    ((:polys7, 2, false, true),),
+    ((:polys8, 2, false, true),),
+    ((:polys2, 2, true, false),),
+    ((:polys3, 2, true, false),),
+    ((:polys4, 4, true, false),),
+    ((:polys7, 2, false, false),),
+    ((:polys8, 2, false, false),),
+    ]
 return (NormConePoly, insts)

--- a/examples/semidefinitepoly/JuMP_test.jl
+++ b/examples/semidefinitepoly/JuMP_test.jl
@@ -1,4 +1,5 @@
 
+relaxed_tols = (default_tol_relax = 1000,)
 insts = OrderedDict()
 insts["minimal"] = [
     ((:matpoly2, true, true),),
@@ -12,7 +13,7 @@ insts["fast"] = [
     ((:matpoly1, false, false), :SOCExpPSD),
     ((:matpoly2, true, true),),
     ((:matpoly2, true, false),),
-    ((:matpoly2, false, false), :SOCExpPSD),
+    ((:matpoly2, false, false), :SOCExpPSD, relaxed_tols),
     ((:matpoly3, true, true),),
     ((:matpoly3, true, false),),
     ((:matpoly3, false, false), :SOCExpPSD),
@@ -22,7 +23,7 @@ insts["fast"] = [
     ((:matpoly6, true, true),),
     ((:matpoly6, true, false),),
     ((:matpoly6, false, false), :SOCExpPSD),
-    ((:matpoly7, true, true),),
+    ((:matpoly7, true, true), nothing, relaxed_tols),
     ((:matpoly7, true, false),),
     ((:matpoly7, false, false), :SOCExpPSD),
     ]

--- a/examples/shapeconregr/JuMP_test.jl
+++ b/examples/shapeconregr/JuMP_test.jl
@@ -1,4 +1,5 @@
 
+relaxed_tols = (default_tol_relax = 1000,)
 insts = OrderedDict()
 insts["minimal"] = [
     ((:naics5811, 3, true, false, true, true, false),),
@@ -47,7 +48,7 @@ insts["various"] = [
     ((8, 100, :func4, 5, 3, true, false, true, true, false),),
     ((8, 100, :func4, 5, 3, false, true, true, true, false),),
     ((8, 100, :func4, 5, 3, false, false, true, true, false),),
-    ((5, 500, :func4, 5, 6, true, true, true, true, false),),
+    ((5, 500, :func4, 5, 6, true, true, true, true, false), nothing, relaxed_tols),
     ((5, 500, :func4, 5, 6, true, false, true, true, false),),
     ((:naics5811, 3, true, true, true, true, false),),
     ((:naics5811, 3, true, false, true, true, false),),

--- a/examples/signomialmin/JuMP_test.jl
+++ b/examples/signomialmin/JuMP_test.jl
@@ -28,7 +28,7 @@ insts["various"] = [
     ((:motzkin3,),),
     ((:CS16ex8_13,),),
     ((:CS16ex8_14,),),
-    ((:CS16ex18,),),
+    ((:CS16ex18,), nothing, relaxed_tols),
     ((:CS16ex12,),),
     ((:CS16ex13,),),
     ((:MCW19ex1_mod,),),


### PR DESCRIPTION
also removing instances that require zero iterations