### PR TITLE
DNMY: clean up compat and set MOI compat to 1

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -20,15 +20,7 @@ SuiteSparse = "4607b0f0-06f3-5cda-b6b1-a6196a1729e9"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [compat]
-Combinatorics = "1"
-DocStringExtensions = "0.8"
-GenericLinearAlgebra = "0.2"
-IterativeSolvers = "0.8, 0.9"
-LinearMaps = "2.7, 3"
-MathOptInterface = "0.10.6"
-PolynomialRoots = "1"
-Requires = "1"
-SpecialFunctions = "1.4, 2"
+MathOptInterface = "1"
 julia = "1.6"
 
 [extras]


### PR DESCRIPTION
I'll just see if this causes any issues with CI

JuMP doesn't support MOI 1.0 yet, so examples tests fail