### PR TITLE
WSOS fixes

### DIFF
--- a/src/Cones/wsosinterpepinormeucl.jl
+++ b/src/Cones/wsosinterpepinormeucl.jl
@@ -116,6 +116,7 @@ function setup_extra_data!(cone::WSOSInterpEpiNormEucl{T}) where {T <: Real}
     cone.Λfact = Vector{Any}(undef, K)
     cone.point_views = [view(cone.point, block_idxs(U, i)) for i in 1:R]
     cone.Ps_times = zeros(K)
+    cone.Ps_order = Vector{Int}(undef, K)
     return cone
 end
 

--- a/src/Cones/wsosinterpepinormeucl.jl
+++ b/src/Cones/wsosinterpepinormeucl.jl
@@ -116,7 +116,6 @@ function setup_extra_data!(cone::WSOSInterpEpiNormEucl{T}) where {T <: Real}
     cone.Λfact = Vector{Any}(undef, K)
     cone.point_views = [view(cone.point, block_idxs(U, i)) for i in 1:R]
     cone.Ps_times = zeros(K)
-    cone.Ps_order = collect(1:K)
     return cone
 end
 
@@ -134,7 +133,7 @@ function update_feas(cone::WSOSInterpEpiNormEucl)
     point_views = cone.point_views
 
     # order the Ps by how long it takes to check feasibility, to improve efficiency
-    sortperm!(cone.Ps_order, cone.Ps_times, initialized = true) # stochastic
+    sortperm!(cone.Ps_order, cone.Ps_times) # stochastic
 
     cone.is_feas = true
     for k in cone.Ps_order

--- a/src/Cones/wsosinterpepinormone.jl
+++ b/src/Cones/wsosinterpepinormone.jl
@@ -137,7 +137,6 @@ function setup_extra_data!(cone::WSOSInterpEpiNormOne{T}) where {T <: Real}
     cone.Λfact = Vector{Any}(undef, K)
     cone.point_views = [view(cone.point, block_idxs(U, i)) for i in 1:R]
     cone.Ps_times = zeros(K)
-    cone.Ps_order = collect(1:K)
     return cone
 end
 
@@ -166,7 +165,7 @@ function update_feas(cone::WSOSInterpEpiNormOne)
     point_views = cone.point_views
 
     # order the Ps by how long it takes to check feasibility, to improve efficiency
-    sortperm!(cone.Ps_order, cone.Ps_times, initialized = true) # stochastic
+    sortperm!(cone.Ps_order, cone.Ps_times) # stochastic
 
     cone.is_feas = true
     for k in cone.Ps_order

--- a/src/Cones/wsosinterpepinormone.jl
+++ b/src/Cones/wsosinterpepinormone.jl
@@ -137,6 +137,7 @@ function setup_extra_data!(cone::WSOSInterpEpiNormOne{T}) where {T <: Real}
     cone.Λfact = Vector{Any}(undef, K)
     cone.point_views = [view(cone.point, block_idxs(U, i)) for i in 1:R]
     cone.Ps_times = zeros(K)
+    cone.Ps_order = Vector{Int}(undef, K)
     return cone
 end
 

--- a/src/Cones/wsosinterpnonnegative.jl
+++ b/src/Cones/wsosinterpnonnegative.jl
@@ -90,7 +90,6 @@ function setup_extra_data!(
     K = length(Ls)
     cone.ΛF = Vector{Any}(undef, K)
     cone.Ps_times = zeros(K)
-    cone.Ps_order = collect(1:K)
     return cone
 end
 
@@ -101,7 +100,7 @@ function update_feas(cone::WSOSInterpNonnegative)
     D = Diagonal(cone.point)
 
     # order the Ps by how long it takes to check feasibility, to improve efficiency
-    sortperm!(cone.Ps_order, cone.Ps_times, initialized = true) # stochastic
+    sortperm!(cone.Ps_order, cone.Ps_times) # stochastic
 
     cone.is_feas = true
     for k in cone.Ps_order

--- a/src/Cones/wsosinterpnonnegative.jl
+++ b/src/Cones/wsosinterpnonnegative.jl
@@ -90,6 +90,7 @@ function setup_extra_data!(
     K = length(Ls)
     cone.ΛF = Vector{Any}(undef, K)
     cone.Ps_times = zeros(K)
+    cone.Ps_order = Vector{Int}(undef, K)
     return cone
 end
 

--- a/src/Cones/wsosinterpnonnegative.jl
+++ b/src/Cones/wsosinterpnonnegative.jl
@@ -138,7 +138,7 @@ function update_grad(cone::WSOSInterpNonnegative)
     cone.grad .= 0
     @inbounds for k in eachindex(cone.Ps)
         ΛFLPk = cone.ΛFLP[k] # computed here
-        ldiv!(ΛFLPk, cone.ΛF[k].L, cone.Ps[k]')
+        ldiv!(ΛFLPk, cone.ΛF[k].L, transpose(cone.Ps[k]))
         @views for j in 1:(cone.dim)
             cone.grad[j] -= sum(abs2, ΛFLPk[:, j])
         end

--- a/src/Cones/wsosinterppossemideftri.jl
+++ b/src/Cones/wsosinterppossemideftri.jl
@@ -106,7 +106,6 @@ function setup_extra_data!(cone::WSOSInterpPosSemidefTri{T}) where {T <: Real}
     cone.PΛiP_blocks_U =
         [view(cone.PΛiP, block_idxs(U, r), block_idxs(U, s)) for r in 1:R, s in 1:R]
     cone.Ps_times = zeros(K)
-    cone.Ps_order = collect(1:K)
     return cone
 end
 
@@ -124,7 +123,7 @@ function update_feas(cone::WSOSInterpPosSemidefTri)
     @assert !cone.feas_updated
 
     # order the Ps by how long it takes to check feasibility, to improve efficiency
-    sortperm!(cone.Ps_order, cone.Ps_times, initialized = true) # stochastic
+    sortperm!(cone.Ps_order, cone.Ps_times) # stochastic
 
     cone.is_feas = true
     for k in cone.Ps_order

--- a/src/Cones/wsosinterppossemideftri.jl
+++ b/src/Cones/wsosinterppossemideftri.jl
@@ -106,6 +106,7 @@ function setup_extra_data!(cone::WSOSInterpPosSemidefTri{T}) where {T <: Real}
     cone.PΛiP_blocks_U =
         [view(cone.PΛiP, block_idxs(U, r), block_idxs(U, s)) for r in 1:R, s in 1:R]
     cone.Ps_times = zeros(K)
+    cone.Ps_order = Vector{Int}(undef, K)
     return cone
 end
 


### PR DESCRIPTION
This merge requests contains two fixes for WSOS. The first one is for correctness, the second for performance.

1. None of the papers handles the complex case explicitly, also the coneref documentation only lists the real derivatives. In trying to follow how Hypatia actually computes all the oracles, I found an issue in one place, where the adjoint is taken, though it should be only the transpose. Please check my calculations to be sure: [checkHypatia.pdf](https://github.com/chriscoey/Hypatia.jl/files/10287823/checkHypatia.pdf)
2. In all WSOS-related cones, the time to do the factorization is stored per $P_k$, so that in the next iteration, the fastest ones are checked first. However, you pass `initialized = true` to `sortperm!`, which means that the reshuffled indices from the previous round will be sorted instead of `1:K` (as the times are always stored in the position corresponding to the actual indices). So I don't think the vector should be treated as initialized.