### PR TITLE
fix: replace `SuiteSparse_long` with the type of `Sys.WORD_SIZE`

### DIFF
--- a/src/linearalgebra/sparse.jl
+++ b/src/linearalgebra/sparse.jl
@@ -11,7 +11,7 @@ helpers for sparse factorizations and linear solves
 
 import SparseArrays.SparseMatrixCSC
 import SuiteSparse
-const SuiteSparseInt = SuiteSparse.CHOLMOD.SuiteSparse_long
+const SuiteSparseInt = typeof(Sys.WORD_SIZE)
 
 #=
 nonsymmetric


### PR DESCRIPTION
- `SuiteSparse_long` is dropped in Julia 1.10. See[^1]

[^1]:https://github.com/JuliaSparse/SparseArrays.jl/pull/408/files