### PR TITLE
Prep for v0.7.4

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Hypatia"
 uuid = "b99e6be6-89ff-11e8-14f8-45c827f4f8f2"
 repo = "https://github.com/chriscoey/Hypatia.jl.git"
-version = "0.7.3"
+version = "0.7.4"
 
 [deps]
 Combinatorics = "861a8166-3701-5b0c-9a16-15d98fcdc6aa"


### PR DESCRIPTION
In particular, so that https://github.com/chriscoey/Hypatia.jl/pull/828 is in a tagged release for Julia v1.10.