### PR TITLE
Supernodal LDLt factorization.

### DIFF
--- a/src/Hypatia.jl
+++ b/src/Hypatia.jl
@@ -28,6 +28,9 @@ function __init__()
     Requires.@require HSL = "34c5aeac-e683-54a6-a0e9-6e0fdc586c50" include(
         "linearalgebra/HSL.jl",
     )
+    Requires.@require CliqueTrees = "60701a23-6482-424a-84db-faee86b9b1f8" include(
+        "linearalgebra/CliqueTrees.jl",
+    )
 end
 
 # submodules

--- a/src/Solvers/systemsolvers/symindef.jl
+++ b/src/Solvers/systemsolvers/symindef.jl
@@ -194,7 +194,7 @@ function update_lhs(syssolver::SymIndefSparseSystemSolver, solver::Solver)
         end
     end
 
-    solver.time_upfact += @elapsed update_fact(syssolver.fact_cache, syssolver.lhs_sub)
+    solver.time_upfact += @elapsed update_fact(syssolver.fact_cache, syssolver.lhs_sub; npos=solver.model.n)
     solve_subsystem3(syssolver, solver, syssolver.sol_const, syssolver.rhs_const)
 
     return syssolver

--- a/src/linearalgebra/CliqueTrees.jl
+++ b/src/linearalgebra/CliqueTrees.jl
@@ -1,0 +1,79 @@
+#=
+Copyright (c) 2018-2022 Chris Coey, Lea Kapelevich, and contributors
+
+This Julia package Hypatia.jl is released under the MIT license; see LICENSE
+file in the root directory or at https://github.com/jump-dev/Hypatia.jl
+=#
+
+#=
+utilities for CliqueTrees.Multifrontal
+sparse supernodal LDLt factorization
+=#
+
+const MF = CliqueTrees.Multifrontal
+
+mutable struct CliqueTreesCache{T <: Real, Reg <: MF.AbstractRegularization} <: SparseSymCache{T}
+    analyzed::Bool
+    F::MF.FChordalLDLt{:L, T, Int}
+    indices::Vector{Int}
+    signs::Vector{T}
+    reg::Reg
+
+    function CliqueTreesCache{T}(reg::Reg) where {T <: Real, Reg <: MF.AbstractRegularization}
+        cache = new{T, Reg}()
+        cache.analyzed = false
+        cache.reg = reg
+        return cache
+    end
+end
+
+function CliqueTreesCache{T}(; reg::MF.AbstractRegularization=MF.NoRegularization()) where {T <: Real}
+    return CliqueTreesCache{T}(reg)
+end
+
+int_type(::CliqueTreesCache) = Int
+
+function update_fact(
+    cache::CliqueTreesCache{T},
+    A::SparseMatrixCSC{T, Int};
+    npos,
+) where {T <: Real}
+    n = size(A, 1)
+
+    if !cache.analyzed
+        cache.signs = Vector{T}(undef, n)
+        cache.signs[1:npos] .= one(T)
+        cache.signs[npos+1:end] .= -one(T)
+
+        cache.F = MF.ChordalLDLt(Symmetric(A, :L))
+        cache.indices = MF.flatindices(cache.F, Symmetric(A, :L))
+        MF.ldlt!(cache.F; signs=cache.signs, reg=cache.reg, check=false)
+        cache.analyzed = true
+    else
+        # Update values directly via flat indices (avoids full matrix copy)
+        nzval = A.nzval
+        @inbounds for (i, p) in enumerate(cache.indices)
+            if !iszero(p)
+                MF.setflatindex!(cache.F, nzval[i], p)
+            end
+        end
+        MF.ldlt!(cache.F; signs=cache.signs, reg=cache.reg, check=false)
+    end
+
+    if !issuccess(cache.F)
+        @warn("numerical failure: CliqueTrees factorization failed")
+    end
+
+    return
+end
+
+function inv_prod(
+    cache::CliqueTreesCache{T},
+    c::Vector{T},
+    A::SparseMatrixCSC{T, Int},
+    b::Vector{T},
+) where {T <: Real}
+    return MF.ldiv!(c, cache.F, b)
+end
+
+free_memory(::CliqueTreesCache) = nothing

--- a/src/linearalgebra/HSL.jl
+++ b/src/linearalgebra/HSL.jl
@@ -26,7 +26,8 @@ int_type(::HSLSymCache) = Int
 
 function update_fact(
     cache::HSLSymCache{T},
-    A::SparseMatrixCSC{T, Int},
+    A::SparseMatrixCSC{T, Int};
+    npos=nothing,
 ) where {T <: BlasReal}
     if !cache.analyzed
         cache.ma57 = HSL.Ma57(A)

--- a/src/linearalgebra/Pardiso.jl
+++ b/src/linearalgebra/Pardiso.jl
@@ -52,7 +52,7 @@ const PardisoSparseCache = Union{PardisoSymCache, PardisoNonSymCache}
 
 int_type(::PardisoSparseCache) = Int32
 
-function update_fact(cache::PardisoSparseCache, A::SparseMatrixCSC{Float64, Int32})
+function update_fact(cache::PardisoSparseCache, A::SparseMatrixCSC{Float64, Int32}; npos=nothing)
     pardiso = cache.pardiso
 
     if !cache.analyzed

--- a/src/linearalgebra/sparse.jl
+++ b/src/linearalgebra/sparse.jl
@@ -85,7 +85,8 @@ diag_min(::SparseSymCache{Float64}) = sqrt(eps())
 
 function update_fact(
     cache::CHOLMODSymCache{Float64},
-    A::SparseMatrixCSC{Float64, SuiteSparseInt},
+    A::SparseMatrixCSC{Float64, SuiteSparseInt};
+    npos=nothing,
 )
     A_symm = Symmetric(A, :L)
 


### PR DESCRIPTION
I have implemented a supernodal LDLt factorization algorithm in [CliqueTrees.jl](https://github.com/AlgebraicJulia/CliqueTrees.jl). Unlike simplicial algorithms (SuiteSparse, QDLDL.jl, LDLFactorizations.jl) which proceed column-by-column, a supernodal algorithm partitions a sparse matrix into dense submatrices, using BLAS level-3 operations. Supernodal algorithms are generally much faster.

This PR adds this implementation as a backend to Hypatia.jl

### Example

Consider the [stability number](https://github.com/jump-dev/Hypatia.jl/tree/master/examples/stabilitynumber) example from the `examples` directory.

```julia
using CliqueTrees, Hypatia, JuMP, Random
using Hypatia: CliqueTreesCache, CHOLMODSymCache, Optimizer
using Hypatia.Solvers: SymIndefSparseSystemSolver, QRCholDenseSystemSolver
using JuMP.MOI: set, Silent

include("examples/Examples.jl")

using .Examples: StabilityNumber, build

function make_model(n; syssolver)
    inst = StabilityNumber{Float64}(n, false)
    model = build(inst)
    set_optimizer(model, () -> Optimizer{Float64}(; syssolver))
    set(backend(model).optimizer.model.optimizer, Silent(), true)
    return model
end

Random.seed!(42)
syssolver = SymIndefSparseSystemSolver{Float64}(fact_cache=CliqueTreesCache{Float64}())

model = make_model(80; syssolver)
@time optimize!(model)
objective_value(model)
```

### Results

| solver                                         | time (s) | objective value |
| ----------------------------- | -------- | --------------- |
| `CliqueTreesCache`                 | 16.9      | 58.1                    |
| `QRCholDenseSystemSolver` | 38.2     | 58.0                    |
| `CHOLMODSymCache`           | 223.5   | 58.1                    |