### PR TITLE
print header with cone names when verbose

### DIFF
--- a/src/Cones/Cones.jl
+++ b/src/Cones/Cones.jl
@@ -142,6 +142,9 @@ function dder3(cone::Cone, dir::AbstractVector) end
 
 # other oracles and helpers
 
+#fallback for printing cone name
+pretty_name(cone::Cones.Cone) = string(typeof(cone))
+
 use_dual_barrier(cone::Cone)::Bool = cone.use_dual_barrier
 
 function setup_data!(cone::Cone{T}) where {T <: Real}

--- a/src/Cones/doublynonnegativetri.jl
+++ b/src/Cones/doublynonnegativetri.jl
@@ -211,3 +211,7 @@ function dder3(cone::DoublyNonnegativeTri, dir::AbstractVector)
 
     return cone.dder3
 end
+
+function pretty_name(cone::DoublyNonnegativeTri)
+    return (use_dual_barrier(cone) ? "dual " : "") * "doubly nonnegative"
+end

--- a/src/Cones/epinormeucl.jl
+++ b/src/Cones/epinormeucl.jl
@@ -226,3 +226,5 @@ function dder3(cone::EpiNormEucl, dir::AbstractVector)
 
     return dder3
 end
+
+pretty_name(cone::EpiNormEucl) = "Euclidean norm"

--- a/src/Cones/epinorminf.jl
+++ b/src/Cones/epinorminf.jl
@@ -478,3 +478,9 @@ end
 function hess_nz_idxs_col_tril(cone::EpiNormInf{<:Real, <:Complex}, j::Int)
     return (j == 1 ? (1:(cone.dim)) : (iseven(j) ? [j, j + 1] : [j]))
 end
+
+function pretty_name(cone::EpiNormInf)
+    realorcomplex = cone.is_complex ? "complex " : "real "
+    primalordual = use_dual_barrier(cone) ? "one norm" : "infinity norm"
+    return realorcomplex * primalordual
+end

--- a/src/Cones/epinormspectral.jl
+++ b/src/Cones/epinormspectral.jl
@@ -487,3 +487,9 @@ function dder3(cone::EpiNormSpectral{T}, dir::AbstractVector{T}) where {T}
 
     return dder3
 end
+
+function pretty_name(cone::EpiNormSpectral)
+    realorcomplex = cone.is_complex ? "complex " : "real "
+    primalordual = use_dual_barrier(cone) ? "trace norm" : "spectral norm"
+    return realorcomplex * primalordual
+end

--- a/src/Cones/epinormspectraltri.jl
+++ b/src/Cones/epinormspectraltri.jl
@@ -415,3 +415,9 @@ function dder3(cone::EpiNormSpectralTri{T}, dir::AbstractVector{T}) where {T}
 
     return dder3
 end
+
+function pretty_name(cone::EpiNormSpectralTri)
+    realorcomplex = cone.is_complex ? "complex " : "real "
+    primalordual = use_dual_barrier(cone) ? "trace norm" : "spectral norm"
+    return realorcomplex * "Hermitian " * primalordual
+end

--- a/src/Cones/epipersepspectral/epipersepspectral.jl
+++ b/src/Cones/epipersepspectral/epipersepspectral.jl
@@ -99,7 +99,6 @@ include("matrixcsqr.jl")
 
 include("sepspectralfun.jl")
 
-pretty_name(Q::Type{<:ConeOfSquares}) = string(Q)
 pretty_name(Q::Type{<:VectorCSqr}) = "vector"
 function pretty_name(Q::Type{MatrixCSqr{T, R}}) where {T, R}
     return (R <: Complex ? "complex" : "real") * " matrix"

--- a/src/Cones/epipersepspectral/epipersepspectral.jl
+++ b/src/Cones/epipersepspectral/epipersepspectral.jl
@@ -98,3 +98,15 @@ include("vectorcsqr.jl")
 include("matrixcsqr.jl")
 
 include("sepspectralfun.jl")
+
+pretty_name(Q::Type{<:ConeOfSquares}) = string(Q)
+pretty_name(Q::Type{<:VectorCSqr}) = "vector"
+function pretty_name(Q::Type{MatrixCSqr{T, R}}) where {T, R}
+    return (R <: Complex ? "complex" : "real") * " matrix"
+end
+pretty_name(h::SepSpectralFun) = string(typeof(h))
+
+function pretty_name(cone::EpiPerSepSpectral{Q, T}) where {Q, T}
+    primalordual = use_dual_barrier(cone) ? "dual " : ""
+    return primalordual * pretty_name(Q) * " " * pretty_name(cone.h)
+end

--- a/src/Cones/epipersepspectral/sepspectralfun.jl
+++ b/src/Cones/epipersepspectral/sepspectralfun.jl
@@ -38,6 +38,8 @@ function get_initial_point(d::Int, ::NegLogSSF)
     return (1, 1, 1)
 end
 
+pretty_name(h::NegLogSSF) = "negative logarithm"
+
 """
 $(TYPEDEF)
 
@@ -61,6 +63,8 @@ function get_initial_point(d::Int, ::NegEntropySSF)
     # TODO initial central point
     return (1, 1, 1)
 end
+
+pretty_name(h::NegEntropySSF) = "negative entropy"
 
 """
 $(TYPEDEF)
@@ -90,6 +94,8 @@ function get_initial_point(d::Int, ::NegSqrtSSF)
     # TODO initial central point
     return (0, 1, 1)
 end
+
+pretty_name(h::NegSqrtSSF) = "negative square root"
 
 """
 $(TYPEDEF)
@@ -137,6 +143,8 @@ function get_initial_point(d::Int, h::NegPower01SSF)
     # TODO initial central point
     return (0, 1, 1)
 end
+
+pretty_name(h::NegPower01SSF) = "negative power"
 
 """
 $(TYPEDEF)
@@ -191,3 +199,5 @@ function get_initial_point(d::Int, h::Power12SSF)
     # TODO initial central point
     return (2d, 1, 1)
 end
+
+pretty_name(h::Power12SSF) = "power"

--- a/src/Cones/epipersquare.jl
+++ b/src/Cones/epipersquare.jl
@@ -278,3 +278,5 @@ function dder3(cone::EpiPerSquare, dir::AbstractVector)
 
     return dder3
 end
+
+pretty_name(cone::EpiPerSquare) = "halved squared Euclidean norm"

--- a/src/Cones/epirelentropy.jl
+++ b/src/Cones/epirelentropy.jl
@@ -415,3 +415,7 @@ function _newton_ratio_relent(w2, d)
     df = 1 / (v2 - 1) - (w2 - 1) * dv2 / (v2 - 1)^2 + (1 / w2 - dv2 / v2) / 2
     return f / df
 end
+
+function pretty_name(cone::EpiRelEntropy)
+    return (use_dual_barrier(cone) ? "dual " : "") * "vector relative entropy"
+end

--- a/src/Cones/epitrrelentropytri.jl
+++ b/src/Cones/epitrrelentropytri.jl
@@ -691,3 +691,9 @@ function Δ4_ij!(
 
     return Δ4_ij
 end
+
+function pretty_name(cone::EpiTrRelEntropyTri)
+    realorcomplex = cone.is_complex ? "complex " : "real "
+    dualorprimal = use_dual_barrier(cone) ? "dual " : ""
+    return realorcomplex * dualorprimal * "matrix relative entropy"
+end

--- a/src/Cones/generalizedpower.jl
+++ b/src/Cones/generalizedpower.jl
@@ -330,3 +330,7 @@ function dder3(cone::GeneralizedPower, dir::AbstractVector)
 
     return cone.dder3
 end
+
+function pretty_name(cone::GeneralizedPower)
+    return (use_dual_barrier(cone) ? "dual " : "") * "generalized power"
+end

--- a/src/Cones/hypogeomean.jl
+++ b/src/Cones/hypogeomean.jl
@@ -263,3 +263,5 @@ function get_central_ray_hypogeomean(::Type{T}, d::Int) where {T <: Real}
     w = -u * (d + 1 + c) / T(2 * d)
     return (u, w)
 end
+
+pretty_name(cone::HypoGeoMean) = (use_dual_barrier(cone) ? "dual " : "") * "geometric mean"

--- a/src/Cones/hypoperlog.jl
+++ b/src/Cones/hypoperlog.jl
@@ -305,3 +305,5 @@ function _newton_ratio_log(v, d)
         u * d * (-2 + u * v - v^2 * du) / (2 - 2 * u * v)
     return f / df
 end
+
+pretty_name(cone::HypoPerLog) = (use_dual_barrier(cone) ? "dual " : "") * "sum-log"

--- a/src/Cones/hypoperlogdettri.jl
+++ b/src/Cones/hypoperlogdettri.jl
@@ -354,3 +354,9 @@ function dder3(cone::HypoPerLogdetTri, dir::AbstractVector)
 
     return dder3
 end
+
+function pretty_name(cone::HypoPerLogdetTri)
+    realorcomplex = cone.is_complex ? "complex " : "real "
+    dualorprimal = use_dual_barrier(cone) ? "dual " : ""
+    return realorcomplex * dualorprimal * "log-determinant"
+end

--- a/src/Cones/hypopowermean.jl
+++ b/src/Cones/hypopowermean.jl
@@ -297,3 +297,5 @@ function _newton_ratio_powermean(s, α)
     dlogf = 2 / s + 1 / (1 - s) - sum(αi^2 / (αi * s + 1) for αi in α)
     return logf / dlogf
 end
+
+pretty_name(cone::HypoPowerMean) = (use_dual_barrier(cone) ? "dual " : "") * "power mean"

--- a/src/Cones/hyporootdettri.jl
+++ b/src/Cones/hyporootdettri.jl
@@ -325,3 +325,9 @@ function dder3(cone::HypoRootdetTri{T}, dir::AbstractVector{T}) where {T <: Real
 
     return dder3
 end
+
+function pretty_name(cone::HypoRootdetTri)
+    realorcomplex = cone.is_complex ? "complex " : "real "
+    dualorprimal = use_dual_barrier(cone) ? "dual " : ""
+    return realorcomplex * dualorprimal * "root-determinant"
+end

--- a/src/Cones/linmatrixineq.jl
+++ b/src/Cones/linmatrixineq.jl
@@ -161,3 +161,9 @@ function dder3(cone::LinMatrixIneq, dir::AbstractVector)
 
     return dder3
 end
+
+function pretty_name(cone::LinMatrixIneq)
+    realorcomplex = isreal(cone.As) ? "real " : "complex "
+    dualorprimal = use_dual_barrier(cone) ? "dual " : ""
+    return realorcomplex * dualorprimal * "linear matrix inequality"
+end

--- a/src/Cones/matrixepipersquare.jl
+++ b/src/Cones/matrixepipersquare.jl
@@ -423,3 +423,9 @@ function dder3(cone::MatrixEpiPerSquare, dir::AbstractVector)
 
     return dder3
 end
+
+function pretty_name(cone::MatrixEpiPerSquare)
+    realorcomplex = cone.is_complex ? "complex " : "real "
+    dualorprimal = use_dual_barrier(cone) ? "dual " : ""
+    return realorcomplex * dualorprimal * "matrix outer product"
+end

--- a/src/Cones/nonnegative.jl
+++ b/src/Cones/nonnegative.jl
@@ -139,3 +139,5 @@ function get_proxsqr(cone::Nonnegative{T}, irtmu::T, use_max_prox::Bool) where {
         abs2(si * zi * irtmu - 1) for (si, zi) in zip(cone.point, cone.dual_point)
     )
 end
+
+pretty_name(cone::Nonnegative) = "nonnegative"

--- a/src/Cones/possemideftri.jl
+++ b/src/Cones/possemideftri.jl
@@ -202,3 +202,7 @@ function dder3(cone::PosSemidefTri, dir::AbstractVector)
 
     return cone.dder3
 end
+
+function pretty_name(cone::PosSemidefTri)
+    return (cone.is_complex ? "complex " : "real ") * "positive semidefinite"
+end

--- a/src/Cones/possemideftrisparse/possemideftrisparse.jl
+++ b/src/Cones/possemideftrisparse/possemideftrisparse.jl
@@ -128,3 +128,9 @@ include("denseimpl.jl")
 include("cholmodimpl.jl")
 const PSDSparseImplList =
     [(PSDSparseDense, Real), (PSDSparseCholmod, LinearAlgebra.BlasReal)]
+
+function pretty_name(cone::PosSemidefTriSparse)
+    realorcomplex = cone.is_complex ? "complex " : "real "
+    dualorprimal = use_dual_barrier(cone) ? "dual " : ""
+    return realorcomplex * dualorprimal * "sparse positive semidefinite"
+end

--- a/src/Cones/wsosinterpepinormeucl.jl
+++ b/src/Cones/wsosinterpepinormeucl.jl
@@ -408,3 +408,9 @@ function dder3(cone::WSOSInterpEpiNormEucl, dir::AbstractVector)
 
     return dder3
 end
+
+function pretty_name(cone::WSOSInterpEpiNormEucl)
+    primalordual = !use_dual_barrier(cone) ? "dual " : ""
+    conename = "interpolant-basis weighted sum-of-squares polynomial Euclidean norm"
+    return primalordual * conename
+end

--- a/src/Cones/wsosinterpepinormone.jl
+++ b/src/Cones/wsosinterpepinormone.jl
@@ -519,3 +519,9 @@ function dder3(cone::WSOSInterpEpiNormOne, dir::AbstractVector)
 
     return dder3
 end
+
+function pretty_name(cone::WSOSInterpEpiNormOne)
+    primalordual = !use_dual_barrier(cone) ? "dual " : ""
+    conename = "interpolant-basis weighted sum-of-squares polynomial one norm"
+    return primalordual * conename
+end

--- a/src/Cones/wsosinterpnonnegative.jl
+++ b/src/Cones/wsosinterpnonnegative.jl
@@ -209,3 +209,10 @@ function partial_lambda!(LUk::Matrix, dir::AbstractVector, LLk::Matrix, ΛFLPk::
     mul!(LUk, Hermitian(LLk), ΛFLPk)
     return LUk
 end
+
+function pretty_name(cone::WSOSInterpNonnegative{T, R}) where {T, R}
+    realorcomplex = R <: Real ? "real " : "complex "
+    primalordual = !use_dual_barrier(cone) ? "dual " : ""
+    conename = "interpolant-basis weighted sum-of-squares polynomial"
+    return realorcomplex * primalordual * conename
+end

--- a/src/Cones/wsosinterppossemideftri.jl
+++ b/src/Cones/wsosinterppossemideftri.jl
@@ -356,3 +356,9 @@ function partial_prod!(
 
     return prod
 end
+
+function pretty_name(cone::WSOSInterpPosSemidefTri)
+    primalordual = !use_dual_barrier(cone) ? "dual " : ""
+    conename = "interpolant-basis weighted sum-of-squares polynomial positive semidefinite"
+    return primalordual * conename
+end

--- a/src/Hypatia.jl
+++ b/src/Hypatia.jl
@@ -13,6 +13,20 @@ module Hypatia
 using DocStringExtensions
 const RealOrComplex{T <: Real} = Union{T, Complex{T}}
 
+function _get_version()
+    project = joinpath(@__DIR__, "../Project.toml")
+    versionline = ""
+    for line in eachline(project)
+        if startswith(line, "version")
+            versionline *= line
+            break
+        end
+    end
+    return strip(split(versionline, "=")[2], (' ', '\"'))
+end
+
+const HYPATIA_VERSION = _get_version()
+
 # linear algebra helpers
 using LinearAlgebra
 using GenericLinearAlgebra

--- a/src/Solvers/Solvers.jl
+++ b/src/Solvers/Solvers.jl
@@ -803,6 +803,7 @@ _plural(n::Integer) = n == 1 ? "" : "s"
 
 # verbose helpers
 function print_header(stepper::Stepper, solver::Solver{T}) where {T}
+    println()
     println("Hypatia v" * HYPATIA_VERSION)
     println()
     model = solver.model

--- a/src/Solvers/Solvers.jl
+++ b/src/Solvers/Solvers.jl
@@ -31,6 +31,7 @@ import Hypatia.nonsymm_fact_copy!
 import Hypatia.symm_fact_copy!
 import Hypatia.posdef_fact_copy!
 import Hypatia.outer_prod!
+import Hypatia.HYPATIA_VERSION
 
 const RealOrNothing = Union{Real, Nothing}
 
@@ -798,8 +799,23 @@ function free_memory(syssolver::Union{NaiveSparseSystemSolver, SymIndefSparseSys
     return free_memory(syssolver.fact_cache)
 end
 
+_plural(n::Integer) = n == 1 ? "" : "s"
+
 # verbose helpers
-function print_header(stepper::Stepper, solver::Solver)
+function print_header(stepper::Stepper, solver::Solver{T}) where {T}
+    println("Hypatia v" * HYPATIA_VERSION)
+    println()
+    model = solver.model
+    @printf "Floating-point type: %s." string(T)
+    println()
+    @printf "Problem with %i variable%s, %i equality constraint%s and %i cone%s:" model.n _plural(
+        model.n,
+    ) model.p _plural(model.p) length(model.cones) _plural(length(model.cones))
+    println()
+    for (cone, idxs) in zip(model.cones, model.cone_idxs)
+        @printf "%i-dimensional %s cone." length(idxs) Cones.pretty_name(cone)
+        println()
+    end
     println()
     @printf("%5s %12s %12s |%9s ", "iter", "p_obj", "d_obj", "abs_gap")
     if iszero(solver.model.p)

--- a/test/cone.jl
+++ b/test/cone.jl
@@ -709,7 +709,8 @@ end
 # EpiPerSepSpectral
 function test_oracles(C::Type{<:Cones.EpiPerSepSpectral})
     for h_fun in sep_spectral_funs
-        @test Cones.pretty_name(h_fun) != @invoke Cones.pretty_name(h_fun::Cones.SepSpectralFun)
+        @test Cones.pretty_name(h_fun) !=
+              @invoke Cones.pretty_name(h_fun::Cones.SepSpectralFun)
         for d in [1, 2, 3, 6]
             test_oracles(C(h_fun, d), init_tol = Inf)
         end

--- a/test/cone.jl
+++ b/test/cone.jl
@@ -36,6 +36,8 @@ function test_oracles(
     init_only::Bool = false,
     init_tol::Real = tol,
 ) where {T <: Real}
+    @test Cones.pretty_name(cone) != @invoke Cones.pretty_name(cone::Cones.Cone)
+
     Random.seed!(1)
     dim = Cones.dimension(cone)
     Cones.setup_data!(cone)

--- a/test/cone.jl
+++ b/test/cone.jl
@@ -708,8 +708,11 @@ end
 
 # EpiPerSepSpectral
 function test_oracles(C::Type{<:Cones.EpiPerSepSpectral})
-    for d in [1, 2, 3, 6], h_fun in sep_spectral_funs
-        test_oracles(C(h_fun, d), init_tol = Inf)
+    for h_fun in sep_spectral_funs
+        @test Cones.pretty_name(h_fun) != @invoke Cones.pretty_name(h_fun::Cones.SepSpectralFun)
+        for d in [1, 2, 3, 6]
+            test_oracles(C(h_fun, d), init_tol = Inf)
+        end
     end
 end
 


### PR DESCRIPTION
It has annoyed me for years that Hypatia doesn't print any information about the model it is actually solving, making it annoying to debug it. I added a header printing some information in verbose mode, in the style of SCS. It includes solver version, number of variables, number of constraints, number of cones, and a list of used cones and their dimensions.